### PR TITLE
Update footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,8 +17,6 @@
          <ul class="nav nav-list">
           <li class="nav-header">Manuals</li>
           <li><a href="/quickstart/">Quickstart</a></li>
-          <li><a href="/manuals/2.6.0/">2.6.x</a></li>
-          <li><a href="/manuals/developer/">Developer</a></li>
          </ul>
         </div>
         <div class="span3 sitemap">


### PR DESCRIPTION
Removed: <li><a href="/manuals/2.6.0/">2.6.x</a></li> and <li><a href="/manuals/developer/">Developer</a></li> due to no content for the links.