### PR TITLE
Feat.: add support for Debian 11 Bullseye

### DIFF
--- a/signatures/2.8.x/latest.json
+++ b/signatures/2.8.x/latest.json
@@ -781,6 +781,29 @@
         "kernel_options": "",
         "kernel_options_post": "",
         "boot_files": []
+      },
+      "bullseye": {
+        "signatures": [
+          "dists"
+        ],
+        "version_file": "Release",
+        "version_file_regex": "Codename: bullseye",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.gz",
+        "isolinux_ok": false,
+        "default_kickstart": "/var/lib/cobbler/kickstarts/sample.seed",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       }
     },
     "ubuntu": {

--- a/signatures/3.0.x/latest.json
+++ b/signatures/3.0.x/latest.json
@@ -912,6 +912,29 @@
         "kernel_options": "",
         "kernel_options_post": "",
         "boot_files": []
+      },
+      "bullseye": {
+        "signatures": [
+          "dists"
+        ],
+        "version_file": "Release",
+        "version_file_regex": "Codename: bullseye",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.seed",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       }
     },
     "ubuntu": {

--- a/signatures/latest.json
+++ b/signatures/latest.json
@@ -912,6 +912,29 @@
         "kernel_options": "",
         "kernel_options_post": "",
         "boot_files": []
+      },
+      "bullseye": {
+        "signatures": [
+          "dists"
+        ],
+        "version_file": "Release",
+        "version_file_regex": "Codename: bullseye",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.seed",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       }
     },
     "ubuntu": {


### PR DESCRIPTION
Debian 11 "bullseye" was [released](https://lists.debian.org/debian-announce/2021/msg00004.html) on Sat, 14 Aug 2021.

This PR updates the most recent signature files (for Cobbler 2.8.x / 3.0.x and "regular file" `latest.json`) with "bullseye".