### PR TITLE
fix: Add Cobbler 3.3.2 version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,6 @@ plugins:
   - jekyll-default-layout
   - jekyll-titles-from-headings
 cobbler:
-  version: 3.3.0
-  released: 2021-09-21
-  versions: [3.3.0]
+  version: 3.3.2
+  released: 2022-03-11
+  versions: [3.3.2]

--- a/downloads/3.x.x.md
+++ b/downloads/3.x.x.md
@@ -16,6 +16,8 @@ title: Cobbler 3.x.x
 - [Cobbler 3.2.1](https://github.com/cobbler/cobbler/releases/tag/v3.2.1)
 - [Cobbler 3.2.2](https://github.com/cobbler/cobbler/releases/tag/v3.2.2)
 - [Cobbler 3.3.0](https://github.com/cobbler/cobbler/releases/tag/v3.3.0)
+- [Cobbler 3.3.1](https://github.com/cobbler/cobbler/releases/tag/v3.3.1)
+- [Cobbler 3.3.2](https://github.com/cobbler/cobbler/releases/tag/v3.3.2)
 
 ## Packages
 


### PR DESCRIPTION
We missed some of the files when releasing 3.3.1 and 3.3.2. This will fix it.