### PR TITLE
Add signature for Ubuntu 22.04 (jammy)

### DIFF
--- a/signatures/3.0.x/latest.json
+++ b/signatures/3.0.x/latest.json
@@ -1449,6 +1449,32 @@
         "template_files": "",
         "boot_files": [],
         "boot_loaders": {}
+      },
+      "jammy": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Codename: jammy|Ubuntu 22.04",
+        "kernel_arch": "linux-headers-(.*)\\\\.deb",
+        "kernel_arch_regex": "null",
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.seed",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
       }
     },
     "suse": {

--- a/signatures/latest.json
+++ b/signatures/latest.json
@@ -1576,6 +1576,32 @@
         "template_files": "",
         "boot_files": [],
         "boot_loaders": {}
+      },
+      "jammy": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Codename: jammy|Ubuntu 22.04",
+        "kernel_arch": "linux-headers-(.*)\\\\.deb",
+        "kernel_arch_regex": "null",
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.seed",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
       }
     },
     "suse": {


### PR DESCRIPTION
Hi,
as suggested in the chat, here is my pull request with the signature for jammy. Keep in mind that autoinstall won't work with this until cloud-init support is added to cobbler. Also, as soon as cloud-init support is there, this signature will need updating.
Regards,
dansou901